### PR TITLE
Update readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Terraform 0.11. Pin module version to ~> 1.0. Submit pull-requests to terraform0
 ```hcl
 module "guardduty-notifications" {
   source  = "trussworks/guardduty-notifications/aws"
-  version = "1.0.2"
+  version = "2.1.0"
 
   sns_topic_name_slack = "slack-event"
   sns_topic_name_pagerduty = "pagerduty-infra-alerts"

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@
  * ```hcl
  * module "guardduty-notifications" {
  *   source  = "trussworks/guardduty-notifications/aws"
- *   version = "1.0.2"
+ *   version = "2.1.0"
  *
  *   sns_topic_name_slack = "slack-event"
  *   sns_topic_name_pagerduty = "pagerduty-infra-alerts"


### PR DESCRIPTION
v2.1.0 is the latest version. This simply reflects that should a person want to copy/paste from the registry.