### PR TITLE
adding auto approve to dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -10,3 +10,7 @@ update_configs:
     # Apply dependencies label to PRs
     default_labels:
       - "dependencies"
+    automerged_updates:
+      - match:
+          dependency_type: "all"
+          update_type: "all"


### PR DESCRIPTION
Missed this on the last pass.... this enables Dependabot to just do the thing after a merge.