### PR TITLE
Making components optional, changing parameter names

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@ Enable AWS GuardDuty and configures any findings to be sent to and SNS topic.
 
 Creates the following resources:
 
-* GuardDuty detector to enable GuardDuty
 * CloudWatch event rule to filter GuardDuty Findings
 * CloudWatch event target to send to SNS topic formatted as `GuardDuty finding: <title>`
+
+Optionally, it can also create the GuardDuty detector as well.
 
 
 ## Usage
@@ -14,8 +15,8 @@ module "guardduty-notifications" {
   source  = "trussworks/guardduty-notifications/aws"
   version = "2.1.0"
 
-  sns_topic_name_slack = "slack-event"
-  sns_topic_name_pagerduty = "pagerduty-infra-alerts"
+  sns_topic_slack = aws_sns_topic.slack
+  sns_topic_pagerduty = aws_sns_topic.pagerduty
 }
 ```
 
@@ -25,6 +26,24 @@ module "guardduty-notifications" {
 Terraform 0.12. Pin module version to ~> 2.0. Submit pull-requests to master branch.
 
 Terraform 0.11. Pin module version to ~> 1.0. Submit pull-requests to terraform011 branch.
+
+## Upgrade Notice v2.x.x to v3.x.x
+
+Version 3 makes a number of changes to the module that will break if it
+is updated in place. Specifically:
+
+* The GuardDuty detector is now an optional part of the module, and
+  defaults to off; if you are leaving the GuardDuty detector in this
+  module, you will need to add "create\_detector = true" as a parameter
+  and do a `terraform state mv` of the detector like so:
+
+  ```console
+  terraform state mv module.module_name.aws_guardduty_detector.main module.module_name.aws_guardduty_detector.main[0]
+  ```
+
+* The `sns_topic_name_slack` and `sns_topic_name_pagerduty` variables
+  have been renamed `sns_topic_slack` and `sns_topic_pagerduty` because
+  they are not actually names, but the actual SNS topic objects.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
@@ -43,8 +62,11 @@ Terraform 0.11. Pin module version to ~> 1.0. Submit pull-requests to terraform0
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| sns\_topic\_name\_pagerduty | PagerDuty SNS Topic Object. | `object({ arn = string, name = string })` | n/a | yes |
-| sns\_topic\_name\_slack | Slack SNS Topic Object. | `object({ arn = string, name = string })` | n/a | yes |
+| create\_detector | Create GuardDuty detector | `bool` | `false` | no |
+| pagerduty\_notifications | Enable PagerDuty notifications for GuardDuty findings | `bool` | `true` | no |
+| slack\_notifications | Enable Slack notifications for GuardDuty findings | `bool` | `true` | no |
+| sns\_topic\_pagerduty | PagerDuty SNS Topic Object. | `object({ arn = string, name = string })` | n/a | yes |
+| sns\_topic\_slack | Slack SNS Topic Object. | `object({ arn = string, name = string })` | n/a | yes |
 
 ## Outputs
 

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -10,6 +10,8 @@ resource "aws_sns_topic" "pagerduty" {
 module "guardduty-notifications" {
   source = "../../"
 
-  sns_topic_name_slack     = aws_sns_topic.slack
-  sns_topic_name_pagerduty = aws_sns_topic.pagerduty
+  create_detector = true
+
+  sns_topic_slack     = aws_sns_topic.slack
+  sns_topic_pagerduty = aws_sns_topic.pagerduty
 }

--- a/main.tf
+++ b/main.tf
@@ -3,6 +3,8 @@
 #
 
 resource "aws_guardduty_detector" "main" {
+  count = var.create_detector ? 1 : 0
+
   enable = true
 }
 
@@ -19,9 +21,11 @@ resource "aws_cloudwatch_event_rule" "main" {
 # More details about the response syntax can be found here:
 # https://docs.aws.amazon.com/guardduty/latest/ug/get-findings.html#get-findings-response-syntax
 resource "aws_cloudwatch_event_target" "slack" {
+  count = var.slack_notifications ? 1 : 0
+
   rule      = aws_cloudwatch_event_rule.main.name
   target_id = "send-to-sns-slack"
-  arn       = var.sns_topic_name_slack.arn
+  arn       = var.sns_topic_slack.arn
 
   input_transformer {
     input_paths = {
@@ -36,8 +40,10 @@ resource "aws_cloudwatch_event_target" "slack" {
 }
 
 resource "aws_cloudwatch_event_target" "pagerduty" {
+  count = var.pagerduty_notifications ? 1 : 0
+
   rule      = aws_cloudwatch_event_rule.main.name
   target_id = "send-to-sns-pagerduty"
-  arn       = var.sns_topic_name_pagerduty.arn
+  arn       = var.sns_topic_pagerduty.arn
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,9 +1,27 @@
-variable "sns_topic_name_slack" {
+variable "create_detector" {
+  description = "Create GuardDuty detector"
+  type        = bool
+  default     = false
+}
+
+variable "pagerduty_notifications" {
+  description = "Enable PagerDuty notifications for GuardDuty findings"
+  type        = bool
+  default     = true
+}
+
+variable "slack_notifications" {
+  description = "Enable Slack notifications for GuardDuty findings"
+  type        = bool
+  default     = true
+}
+
+variable "sns_topic_slack" {
   description = "Slack SNS Topic Object."
   type        = object({ arn = string, name = string })
 }
 
-variable "sns_topic_name_pagerduty" {
+variable "sns_topic_pagerduty" {
   description = "PagerDuty SNS Topic Object."
   type        = object({ arn = string, name = string })
 }


### PR DESCRIPTION
When I was in the process of testing out @kilbergr's work with the GuardDuty notifications stuff, I realized the way this module was working wasn't really great; creating the GuardDuty detector didn't really seem like it should be part of this module, and we also don't need PagerDuty for GuardDuty alerts in the trussworks org so I wanted to make that optional as well (and I just made the slack ones optional at the same time). I made sure to add an upgrade note to the README.