### PR TITLE
Switch input params from objects to ARNs

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ is updated in place. Specifically:
 | create\_detector | Create GuardDuty detector | `bool` | `false` | no |
 | pagerduty\_notifications | Enable PagerDuty notifications for GuardDuty findings | `bool` | `true` | no |
 | slack\_notifications | Enable Slack notifications for GuardDuty findings | `bool` | `true` | no |
-| sns\_topic\_pagerduty | PagerDuty SNS Topic Object. | `object({ arn = string, name = string })` | <pre>{<br>  "arn": "",<br>  "name": ""<br>}</pre> | no |
-| sns\_topic\_slack | Slack SNS Topic Object. | `object({ arn = string, name = string })` | <pre>{<br>  "arn": "",<br>  "name": ""<br>}</pre> | no |
+| sns\_topic\_pagerduty\_arn | PagerDuty SNS Topic ARN | `string` | `""` | no |
+| sns\_topic\_slack\_arn | Slack SNS Topic ARN | `string` | `""` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Optionally, it can also create the GuardDuty detector as well.
 ```hcl
 module "guardduty-notifications" {
   source  = "trussworks/guardduty-notifications/aws"
-  version = "3.0.0"
+  version = "5.0.0"
 
   sns_topic_slack_arn     = aws_sns_topic.slack.arn
   sns_topic_pagerduty_arn = aws_sns_topic.pagerduty.arn
@@ -31,9 +31,9 @@ Terraform 0.12. Pin module version to ~> 3.0.0 Submit pull-requests to master br
 
 * The `sns_topic_slack` and `sns_topic_pagerduty` variables have been
   renamed to `sns_topic_slack_arn` and `sns_topic_pagerduty_arn`; they
-  are also taking arns as values, and not `aws_sns_topic` objects. We
+  are also taking ARNs as values, and not `aws_sns_topic` objects. We
   made this change to better handle the outputs of the `notify-slack`
-  Terraform module, which outputs names and arns, but not objects.
+  Terraform module, which outputs names and ARNs, but not objects.
 
 ## Upgrade Notice v2.x.x to v3.x.x
 

--- a/README.md
+++ b/README.md
@@ -15,17 +15,25 @@ module "guardduty-notifications" {
   source  = "trussworks/guardduty-notifications/aws"
   version = "3.0.0"
 
-  sns_topic_slack = aws_sns_topic.slack
-  sns_topic_pagerduty = aws_sns_topic.pagerduty
+  sns_topic_slack_arn     = aws_sns_topic.slack.arn
+  sns_topic_pagerduty_arn = aws_sns_topic.pagerduty.arn
 }
 ```
 
 
 ## Terraform Versions
 
-Terraform 0.13 or later. Pin module version to ~> 4.0.0 Submit pull-requests to master branch.
+Terraform 0.13 or later. Pin module version to ~> 5.0.0 Submit pull-requests to master branch.
 
 Terraform 0.12. Pin module version to ~> 3.0.0 Submit pull-requests to master branch.
+
+## Upgrade Notice v4.x.x to v5.x.x
+
+* The `sns_topic_slack` and `sns_topic_pagerduty` variables have been
+  renamed to `sns_topic_slack_arn` and `sns_topic_pagerduty_arn`; they
+  are also taking arns as values, and not `aws_sns_topic` objects. We
+  made this change to better handle the outputs of the `notify-slack`
+  Terraform module, which outputs names and arns, but not objects.
 
 ## Upgrade Notice v2.x.x to v3.x.x
 

--- a/examples/no-pagerduty/main.tf
+++ b/examples/no-pagerduty/main.tf
@@ -9,5 +9,5 @@ module "guardduty-notifications" {
 
   pagerduty_notifications = false
 
-  sns_topic_slack = aws_sns_topic.slack
+  sns_topic_slack_arn = aws_sns_topic.slack.arn
 }

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -12,6 +12,6 @@ module "guardduty-notifications" {
 
   create_detector = false
 
-  sns_topic_slack     = aws_sns_topic.slack
-  sns_topic_pagerduty = aws_sns_topic.pagerduty
+  sns_topic_slack_arn     = aws_sns_topic.slack.arn
+  sns_topic_pagerduty_arn = aws_sns_topic.pagerduty.arn
 }

--- a/main.tf
+++ b/main.tf
@@ -25,7 +25,7 @@ resource "aws_cloudwatch_event_target" "slack" {
 
   rule      = aws_cloudwatch_event_rule.main.name
   target_id = "send-to-sns-slack"
-  arn       = var.sns_topic_slack.arn
+  arn       = var.sns_topic_slack_arn
 
   input_transformer {
     input_paths = {
@@ -44,6 +44,6 @@ resource "aws_cloudwatch_event_target" "pagerduty" {
 
   rule      = aws_cloudwatch_event_rule.main.name
   target_id = "send-to-sns-pagerduty"
-  arn       = var.sns_topic_pagerduty.arn
+  arn       = var.sns_topic_pagerduty_arn
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -16,14 +16,14 @@ variable "slack_notifications" {
   default     = true
 }
 
-variable "sns_topic_slack" {
-  description = "Slack SNS Topic Object."
-  type        = object({ arn = string, name = string })
-  default     = { arn = "", name = "" }
+variable "sns_topic_slack_arn" {
+  description = "Slack SNS Topic ARN"
+  type        = string
+  default     = ""
 }
 
-variable "sns_topic_pagerduty" {
-  description = "PagerDuty SNS Topic Object."
-  type        = object({ arn = string, name = string })
-  default     = { arn = "", name = "" }
+variable "sns_topic_pagerduty_arn" {
+  description = "PagerDuty SNS Topic ARN"
+  type        = string
+  default     = ""
 }


### PR DESCRIPTION
Barry switched the input for the SNS topics from names to objects when that became possible with 0.12, but the `notify-slack` module only outputs names and ARNs. This means that in order to use the topic that module creates, we'd have to use a data object to capture it, or create the SNS topic outside the module and then use it as inputs for both that module and this one. In order to make things simpler, I just made this module take an ARN as an input value to start with.

Note that because this is a breaking change, this will be a v5.0.0 release when I cut one.