### PR TITLE
deprecate older terraform versions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,5 +11,3 @@ on:
 jobs:
   validate-tf:
     uses: trussworks/shared-actions/.github/workflows/validate-tf.yml@main
-    with:
-      go-version: 1.19

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,12 +34,6 @@ repos:
     hooks:
       - id: shell-lint
 
-  - repo: https://github.com/terraform-docs/terraform-docs
-    rev: "v0.16.0"
-    hooks:
-      - id: terraform-docs-go
-        args: ["markdown", "table", "--output-file", "README.md", "."]
-
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.77.1
     hooks:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ is updated in place. Specifically:
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.13.0 |
+| terraform | >= 1.0 |
 | aws | >= 3.0 |
 
 ## Providers

--- a/README.md
+++ b/README.md
@@ -19,12 +19,6 @@ module "guardduty-notifications" {
 }
 ```
 
-## Terraform Versions
-
-Terraform 0.13 or later. Pin module version to ~> 5.0.0 Submit pull-requests to master branch.
-
-Terraform 0.12. Pin module version to ~> 3.0.0 Submit pull-requests to master branch.
-
 ## Upgrade Notice v4.x.x to v5.x.x
 
 - The `sns_topic_slack` and `sns_topic_pagerduty` variables have been

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = ">= 3.0"


### PR DESCRIPTION
-   Modified README
-   Set expected terraform version to be equal or greater than Terraform version 1.0
